### PR TITLE
Fixed issue with missing category specifier

### DIFF
--- a/Source/BlueprintSubsystems/Public/BlueprintsSubsystemDeveloperSettings.h
+++ b/Source/BlueprintSubsystems/Public/BlueprintsSubsystemDeveloperSettings.h
@@ -38,6 +38,6 @@ public:
 	* saved to the configuration file.
 	* @see UBlueprintSubsystemManager
 	*/
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, Config, DisplayName="Subsystem List")
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Config, DisplayName="Subsystem List", Category = "Details")
 	TArray<TSoftClassPtr<UBlueprintSubsystemBase>> ActiveSubsystems;
 };

--- a/Source/BlueprintSubsystems/Public/Subsystems/BlueprintSubsystemManager.h
+++ b/Source/BlueprintSubsystems/Public/Subsystems/BlueprintSubsystemManager.h
@@ -34,7 +34,7 @@ protected:
 	* @brief Array of blueprint subsystems managed by this manager.
 	* @see UBlueprintsSubsystemDeveloperSettings
 	*/
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "Details")
 	TArray<UBlueprintSubsystemBase*> BlueprintSubsystems;
 
 protected:


### PR DESCRIPTION
Unreal Engine will fail complication because of missing category specifiers in Blueprint related code. I fixed that by simply adding them.